### PR TITLE
refactor use of Gems and add Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
-#after any changes to the Gemfile, execute bundle update!
 source "https://rubygems.org"
-gem "jekyll-remote-theme"
 
-# If you do not want to use GitHub Pages, comment out the line below, then run bundle update.
-#gem "github-pages", group: :jekyll_plugins
+gem "jekyll", "~> 3.9"
+gem "kramdown-parser-gfm", "~> 1.1.0"
+gem "webrick", "~> 1.7"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem "jekyll-remote-theme", "~> 0.4.3"
 end
 
 # Delete the following lines if not on Windows: 

--- a/_config.yml
+++ b/_config.yml
@@ -1,21 +1,8 @@
-# Welcome to Jekyll!
-#
-# This config file is meant for settings that affect your whole blog, values
-# which you are expected to set up once and rarely edit after that.
-# This file is *NOT* reloaded automatically when you use 'bundle exec jekyll serve'.
-# If you change this file, please restart the server process.
-
-# Site settings
-# are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
-
-#theme: jekyll-agency
+theme: jekyll-agency
 remote_theme: raviriley/agency-jekyll-theme
 
-url    : "" # the base hostname & protocol for your site, e.g. http://example.com
-baseurl: "/agency-jekyll-theme-starter" # the subpath of your site, e.g. /blog
+url    : ""
+baseurl: "/agency-jekyll-theme-starter"
 
 title      : Agency Jekyll Theme Demo
 email      : your-email@example.com #this is also the email contact forms will go to
@@ -38,6 +25,3 @@ markdown: kramdown
 # Uncomment following line to use Formspree form ID based URL instead of email based URL
 # Details: https://help.formspree.io/hc/en-us/articles/360017735154-How-to-prevent-spam
 # formspree_form_path: "f/a_form_id"
-
-plugins:
-  - jekyll-remote-theme


### PR DESCRIPTION
If you add remote theme to Gemfile plugins list, you can remove it from config.

Example of my site using a remote theme, without `plugins` field in config


https://github.com/MichaelCurrin/dev-cheatsheets/blob/master/Gemfile

https://github.com/MichaelCurrin/dev-cheatsheets/blob/master/_config.yml

the GH Pages gem is very heavy for a ton of gems one doesn't actually need. So I was more selectively with adding Jekyll and some dependencies needed for 3.9 and Ruby 3.
